### PR TITLE
revert: permission handling as keyring access requires manifest origin list

### DIFF
--- a/packages/snap/package.json
+++ b/packages/snap/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bobanetwork/snap-account-abstraction-keyring-hc",
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "An account abstraction keyring snap that integrates with MetaMask accounts on Boba Network",
   "keywords": [
     "metamask",

--- a/packages/snap/snap.manifest.json
+++ b/packages/snap/snap.manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "1.1.27",
+  "version": "1.1.28",
   "description": "An account abstraction keyring snap that integrates with MetaMask accounts on Boba Network",
   "proposedName": "Boba Network Account Abstraction Keyring",
   "repository": {
@@ -7,7 +7,7 @@
     "url": "git+https://github.com/bobanetwork/snap-account-abstraction-keyring-hc.git"
   },
   "source": {
-    "shasum": "RKob+1j9EseFliQUjWAmPsD+MvTTonMHTfm/hk8izfM=",
+    "shasum": "zK8rEVj22dc1A+g7YHkAxpy8vENNMWndN+kEJuoMqy8=",
     "location": {
       "npm": {
         "filePath": "dist/bundle.js",
@@ -18,6 +18,20 @@
     }
   },
   "initialPermissions": {
+    "endowment:keyring": {
+      "allowedOrigins": [
+        "http://localhost:*",
+        "https://hc-wallet.sepolia.boba.network",
+        "https://aa-hc-example-fe.onrender.com/",
+        "https://boba-blockchain-busters-frontend.onrender.com",
+        "https://presibot.onrender.com",
+        "https://hub.boba.network",
+        "https://staging.hub.boba.network",
+        "https://stagingv2.hub.boba.network",
+        "https://codecaster.onrender.com",
+        "https://pricefeed-frontend.onrender.com"
+      ]
+    },
     "endowment:rpc": {
       "dapps": true
     },

--- a/packages/snap/src/permissions.ts
+++ b/packages/snap/src/permissions.ts
@@ -1,3 +1,5 @@
+import { KeyringRpcMethod } from '@metamask/keyring-api';
+
 export enum InternalMethod {
   ToggleSyncApprovals = 'snap.internal.toggleSynchronousApprovals',
   IsSynchronousMode = 'snap.internal.isSynchronousMode',
@@ -5,47 +7,208 @@ export enum InternalMethod {
   SendUserOpBobaPM = 'eth_sendUserOpBobaPM',
 }
 
-const PERMISSIONS_URL =
-  'https://raw.githubusercontent.com/bobanetwork/snap-account-abstraction-keyring-hc/refs/heads/main/permissions.json';
-
-const defaultPermissions = new Map<string, string[]>([]);
-
-let cachedPermissions: Map<string, string[]> | null = null;
-let lastFetchTime = 0;
-let fetchPromise: Promise<Map<string, string[]>> | null = null;
-const CACHE_DURATION = 5 * 60 * 1000;
-
-export async function getOriginPermissions(): Promise<Map<string, string[]>> {
-  const now = Date.now();
-
-  if (cachedPermissions && now - lastFetchTime < CACHE_DURATION) {
-    return cachedPermissions;
-  }
-
-  if (fetchPromise) {
-    return fetchPromise;
-  }
-
-  fetchPromise = (async () => {
-    try {
-      const response = await fetch(PERMISSIONS_URL);
-      const data = (await response.json()) as Record<string, string[]>;
-      const permissions = new Map(Object.entries(data));
-      cachedPermissions = permissions;
-      lastFetchTime = Date.now();
-      return permissions;
-    } catch (error) {
-      console.error(
-        '[Snap] Error fetching permissions, using defaults:',
-        error,
-      );
-      cachedPermissions = defaultPermissions;
-      lastFetchTime = Date.now();
-      return defaultPermissions;
-    } finally {
-      fetchPromise = null;
-    }
-  })();
-
-  return fetchPromise;
-}
+export const originPermissions = new Map<string, string[]>([
+  [
+    'metamask',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.RejectRequest,
+    ],
+  ],
+  [
+    'http://localhost',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+  [
+    'https://hub.boba.network',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+  [
+    'https://staging.hub.boba.network',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+  [
+    'https://stagingv2.hub.boba.network',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+  [
+    'https://hc-wallet.sepolia.boba.network',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+  [
+    'https://aa-hc-example-fe.onrender.com',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+  [
+    'https://presibot.onrender.com',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+  [
+    'https://codecaster.onrender.com',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+  [
+    'https://pricefeed-frontend.onrender.com',
+    [
+      // Keyring methods
+      KeyringRpcMethod.ListAccounts,
+      KeyringRpcMethod.GetAccount,
+      KeyringRpcMethod.CreateAccount,
+      KeyringRpcMethod.FilterAccountChains,
+      KeyringRpcMethod.UpdateAccount,
+      KeyringRpcMethod.DeleteAccount,
+      KeyringRpcMethod.ExportAccount,
+      KeyringRpcMethod.SubmitRequest,
+      KeyringRpcMethod.ListRequests,
+      KeyringRpcMethod.GetRequest,
+      KeyringRpcMethod.ApproveRequest,
+      KeyringRpcMethod.RejectRequest,
+      // Custom methods
+      InternalMethod.SendUserOpBoba,
+      InternalMethod.SendUserOpBobaPM,
+    ],
+  ],
+]);


### PR DESCRIPTION
- `endowment:rpc` can omit the local permission list (verified).
- `endowment:keyring` with an empty origins list builds successfully, but fails at runtime during keyring access (verified). 
- This change has been reverted in this commit, `v1.28`. 
- `permission.json` list is kept, as there might be the possibility that this will be made easier in the future
- Though no statement could be found that the `allowOrigins` property may be publicly opened, or dynamically accessible. For now, the allowlist must be included within the `snap manifest` and cannot be dynamically inserted, as otherwise the shasum will be altered, too.